### PR TITLE
Remove rotation of the Cornell Box scene from xml file.

### DIFF
--- a/example-scenes/CornellBox.xml
+++ b/example-scenes/CornellBox.xml
@@ -9,7 +9,7 @@
 	<object type="tree" name="root">
 		<transblock>
 			<translate x="0" y="2" z="0"/>
-                        <rotate x="0" y="0" z="1" angle="180"/>
+                        <rotate x="0" y="0" z="1" angle="0"/>
 			<object type="primitive" name="mesh" filename="models/CornellBox/CornellBox-Original.obj">
 			</object>
 		</transblock>


### PR DESCRIPTION
Previously the scene was rotated on the z axis by 180 degrees, which caused some confusion for students.